### PR TITLE
Add CI auto tag 

### DIFF
--- a/.github/workflows /autotag.yml
+++ b/.github/workflows /autotag.yml
@@ -1,0 +1,36 @@
+name: Auto Tag
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Patch:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Minor version for each merge
+      id: taggerDryRun
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DRY_RUN: true
+
+    - name: echo new tag
+      run: |
+        echo "The next tag version will be: ${{ steps.taggerDryRun.outputs.new_tag }}"
+    - name: echo tag
+      run: |
+        echo "The current tag is: ${{ steps.taggerDryRun.outputs.tag }}"
+    - name: echo part
+      run: |
+        echo "The version increment was: ${{ steps.taggerDryRun.outputs.part }}"
+
+    - name: Minor version for each merge
+      id: taggerFinal
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true


### PR DESCRIPTION
Each version is defined as major.minor.patch. The auto tag CI increases **minor** automatically with each push unless stated otherwise. To increase major add a commit with `#major` on the commit message. To add a patch add a commit with `#minor` on the commit message.