### PR TITLE
Ondra move detection prob to defender

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -3,7 +3,6 @@
 # Author: sebastian garcia, sebastian.garcia@agents.fel.cvut.cz
 # Author: Ondrej Lukas, ondrej.lukas@aic.fel.cvut.cz
 import argparse
-from datetime import datetime
 import logging
 import json
 import asyncio
@@ -12,7 +11,6 @@ from env.game_components import Action, Observation, ActionType, GameStatus
 from utils.utils import observation_as_dict
 from pathlib import Path
 import os
-import time
 
 
 class AIDojo:
@@ -29,7 +27,7 @@ class AIDojo:
             self._action_queue,
             self._answer_queue,
             net_set_config,
-            ALLOWED_ROLES=["Attacker", "Defender", "Human"],
+            allowed_roles=["Attacker", "Defender", "Human"],
         )
 
     def run(self):
@@ -179,10 +177,10 @@ class ConnectionLimitServer(asyncio.Protocol):
 
 
 class Coordinator:
-    def __init__(self, actions_queue, answers_queue, net_set_config, ALLOWED_ROLES):
+    def __init__(self, actions_queue, answers_queue, net_set_config, allowed_roles):
         self._actions_queue = actions_queue
         self._answers_queue = answers_queue
-        self.ALLOWED_ROLES = ALLOWED_ROLES
+        self.ALLOWED_ROLES = allowed_roles
         self.logger = logging.getLogger("AIDojo-Coordinator")
         self._world = NetworkSecurityEnvironment(net_set_config)
         self._action_processor = ActionProcessor()

--- a/env/netsecenv_conf.yaml
+++ b/env/netsecenv_conf.yaml
@@ -61,7 +61,12 @@ coordinator:
         exfiltrate_data:
           consecutive_actions: 2
           tw_ratio: 0.25
-
+      action_detetection_prob:
+        scan_network: 0.05
+        find_services: 0.075
+        exploit_service: 0.1
+        find_data: 0.025
+        exfiltrate_data: 0.025
 env:
   # random means to choose the seed in a random way, so it is not fixed
   random_seed: 'random'

--- a/env/netsecenv_conf.yaml
+++ b/env/netsecenv_conf.yaml
@@ -5,7 +5,7 @@ coordinator:
   agents:
     attackers:
       goal:
-        randomize_goal_every_episode: True
+        randomize_goal_every_episode: False
         known_networks: []
         #known_networks: [192.168.1.0/24, 192.168.3.0/24]
         known_hosts: []
@@ -72,9 +72,12 @@ env:
   random_seed: 'random'
   # Or you can fix the seed
   # random_seed: 42
-  scenario: 'scenario1'
+  scenario: 'scenario1_tiny'
   max_steps: 100
   store_replay_buffer: False
+  goal_reward: 100
+  detection_reward: -5
+  step_reward: -1
   actions:
     scan_network:
       prob_success: 1.0

--- a/env/netsecenv_conf.yaml
+++ b/env/netsecenv_conf.yaml
@@ -81,16 +81,11 @@ env:
   actions:
     scan_network:
       prob_success: 1.0
-      prob_detection: 0.05
     find_services:
       prob_success: 1.0
-      prob_detection: 0.075
     exploit_services:
       prob_success: 1.0
-      prob_detection: 0.1
     find_data:
       prob_success: 1.0
-      prob_detection: 0.025
     exfiltrate_data:
       prob_success: 1.0
-      prob_detection: 0.025

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -10,8 +10,6 @@ import copy
 from cyst.api.configuration import NodeConfig, RouterConfig, ConnectionConfig, ExploitConfig, FirewallPolicy
 import numpy as np
 import logging
-import os
-from pathlib import Path
 from faker import Faker
 from utils.utils import ConfigParser, store_replay_buffer_in_csv
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -117,7 +117,13 @@ class ConfigParser():
         Generic function to read the known data for any agent and goal of position
         """
         action_success_p = self.config['env']['actions'][action_name]['prob_success']
-        action_detect_p = self.config['env']['actions'][action_name]['prob_detection']
+        try:
+            if self.config["coordinator"]["agents"]["defenders"]["type"] in ["StochasticWithThreshold", "Stochastic"]:
+                action_detect_p = self.config["coordinator"]["agents"]["defenders"]["action_detetection_prob"][action_name]
+            else:
+                action_detect_p = 0
+        except KeyError:
+            action_detect_p = 0
         return action_success_p, action_detect_p
 
     def read_agents_known_data(self, type_agent: str, type_data: str) -> dict:


### PR DESCRIPTION
Since we now have a 'defenders' section of the configuration file, it makes more sense to place the detection probabilities there. It's the property of the stochastic defender NOT the env