### PR TITLE
Ondra add goal description to tasks

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -263,7 +263,11 @@ class Coordinator:
                     "to_agent": agent_addr,
                     "status": str(GameStatus.CREATED),
                     "observation": agent_observation_str,
-                    "message": f"Welcome {agent_name}, registred as {agent_role}",
+                    "message": {
+                        "message": f"Welcome {agent_name}, registred as {agent_role}",
+                        "max_steps": self._world._max_steps,
+                        "goal_description": self._world.get_goal_description()
+                        },
                 }
             else:
                 self.logger.info(

--- a/env/netsecenv_conf.yaml
+++ b/env/netsecenv_conf.yaml
@@ -5,6 +5,7 @@ coordinator:
   agents:
     attackers:
       goal:
+        description: "Exfiltrate data to '213.47.23.195'"
         randomize_goal_every_episode: False
         known_networks: []
         #known_networks: [192.168.1.0/24, 192.168.3.0/24]

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -174,6 +174,11 @@ class NetworkSecurityEnvironment(object):
     def num_actions(self):
         return len(components.ActionType)
 
+    def get_goal_description(self):
+        orig_text = self.task_config.get_goal_description()
+        return orig_text
+            
+
     def get_all_states(self):
         import itertools
         def all_combs(data):

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -168,6 +168,9 @@ class NetworkSecurityEnvironment(object):
             return None
 
     @property
+    def timeout(self):
+        return self._max_steps
+    @property
     def num_actions(self):
         return len(components.ActionType)
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -53,7 +53,8 @@ class TestCoordinator:
 
         assert result["to_agent"] == ("192.168.1.1", "3300")
         assert result["status"] == "GameStatus.CREATED"
-        assert "Welcome" in result["message"]
+        assert "max_steps" in result["message"].keys()
+        assert "goal_description" in result["message"].keys()
         assert not result["observation"]["end"]
         assert result["observation"]["state"] == obs.state.as_dict
         assert result["observation"]["info"] == obs.info

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -155,7 +155,6 @@ class ConfigParser():
         """
         Generic function to read the known services for any agent and goal of position
         """
-        return {}
         known_services_conf = self.config['agents'][type_agent][type_data]['known_services']
         known_services = {}
         for ip, data in known_services_conf.items():
@@ -287,6 +286,16 @@ class ConfigParser():
         max_steps = self.config['env']['max_steps']
         return int(max_steps)
 
+    def get_goal_description(self)->str:
+        """
+        Get goal description
+        """
+        try:
+            description = self.config['coordinator']['agents']["attackers"]["goal"]["description"]
+        except KeyError:
+            description = ""
+        return description
+        
     def get_goal_reward(self)->float:
         """
         Reads  what is the reward for reaching the goal.

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -155,7 +155,7 @@ class ConfigParser():
         """
         Generic function to read the known services for any agent and goal of position
         """
-        known_services_conf = self.config['agents'][type_agent][type_data]['known_services']
+        known_services_conf = self.config["coordinator"]['agents'][type_agent][type_data]['known_services']
         known_services = {}
         for ip, data in known_services_conf.items():
             try:

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -109,7 +109,7 @@ class ConfigParser():
             with open(conf_file_name) as source:
                 self.config = yaml.safe_load(source)
         except (IOError, TypeError):
-            self.logger.error(f'Error loading the configuration file')
+            self.logger.error('Error loading the configuration file')
             pass
 
     def read_env_action_data(self, action_name: str) -> dict:
@@ -188,7 +188,7 @@ class ConfigParser():
                     host_part, net_part = net.split('/')
                     known_networks.add(Network(host_part, int(net_part)))
             except (ValueError, TypeError, netaddr.AddrFormatError):
-                self.logger(f'Configuration problem with the known networks')
+                self.logger('Configuration problem with the known networks')
         return known_networks
 
     def read_agents_known_hosts(self, type_agent: str, type_data: str) -> dict:
@@ -202,7 +202,7 @@ class ConfigParser():
                 _ = netaddr.IPAddress(ip)
                 known_hosts.add(IP(ip))
             except (ValueError, netaddr.AddrFormatError):
-                self.logger(f'Configuration problem with the known hosts')
+                self.logger('Configuration problem with the known hosts')
         return known_hosts
 
     def read_agents_controlled_hosts(self, type_agent: str, type_data: str) -> dict:
@@ -220,7 +220,7 @@ class ConfigParser():
                     # A random start ip was asked for
                     controlled_hosts.add('random')
                 else:
-                    self.logger(f'Configuration problem with the known hosts')
+                    self.logger('Configuration problem with the known hosts')
         return controlled_hosts
 
     def get_attackers_win_conditions(self):
@@ -295,7 +295,7 @@ class ConfigParser():
         except KeyError:
             description = ""
         return description
-        
+
     def get_goal_reward(self)->float:
         """
         Reads  what is the reward for reaching the goal.


### PR DESCRIPTION
The first observation to agent after successful registration contains in the "info" field a dict with  following data:

{"message": "welcome message",
"max_steps:  max steps before timeout, 
"goal_description": string describing the task
}