### PR TITLE
Firewall rules capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The environment part defines the properties of the environment for the task (see
 - `max_steps` - sets the maximum number of steps an agent can make before an episode is terminated
 - `store_replay_buffer` - if `True`, interaction of the agents is serialized and stored in a file
 - `use_dynamic_addresses` - if `True`, the network and IP addresses defined in `scenario` are randomly changed at the beginning of **EVERY** episode (the network topology is kept as defined in the `scenario`. Relations between networks are kept, IPs inside networks are chosen at random based on the network IP and mask)
+- `  use_firewall` - if `True` firewall rules defined in `scenario` are used when executing actions. When `False`, firewall is ignored and all connections are allowed (Default)
 - `goal_reward` - sets reward which agent gets when it reaches the goal (default 100)
 - `detection_reward` - sets reward which agent gets when it is detected (default -50)
 - `step_reward` - sets reward which agent gets for every step taken (default -1)
@@ -103,6 +104,7 @@ env:
   max_steps: 15
   store_replay_buffer: True
   use_dynamic_addresses: False
+  use_firewall: True
   goal_reward: 100
   detection_reward: -5
   step_reward: -1

--- a/env/netsecenv_conf.yaml
+++ b/env/netsecenv_conf.yaml
@@ -78,6 +78,7 @@ env:
   max_steps: 100
   store_replay_buffer: False
   use_dynamic_addresses: False
+  use_firewall: True
   goal_reward: 100
   detection_reward: -5
   step_reward: -1

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -681,6 +681,14 @@ class NetworkSecurityEnvironment(object):
                 new_self_networks[mapping_nets[net]].add(mapping_ips[ip])
         self._networks = new_self_networks
         
+        #self._firewall
+        new_self_firewall = {}
+        for ip, dst_ips in self._firewall.items():
+            new_self_firewall[mapping_ips[ip]] = set()
+            for dst_ip in dst_ips:
+                new_self_firewall[mapping_ips[ip]].add(mapping_ips[dst_ip])
+        self._firewall = new_self_firewall
+        
         #self._ip_to_hostname
         new_self_ip_to_hostname  = {}
         for ip, hostname in self._ip_to_hostname.items():

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -145,11 +145,11 @@ class NetworkSecurityEnvironment(object):
     def __init__(self, task_config_file) -> None:
         logger.info("Initializing NetSetGame environment")
         # Prepare data structures for all environment components (to be filled in self._process_cyst_config())
-        self._ip_to_hostname = {}
-        self._networks = {}
-        self._services = {}
-        self._data = {}
-        self._firewall = {}
+        self._ip_to_hostname = {} # Mapping of `IP`:`host_name`(str) of all nodes in the environment
+        self._networks = {} # A `dict` of the networks present in the environment. Keys: `Network` objects, values `set` of `IP` objects.
+        self._services = {} # Dict of all services in the environment. Keys: hostname (`str`), values: `set` of `Service` objetcs.
+        self._data = {} # Dict of all services in the environment. Keys: hostname (`str`), values `set` of `Service` objetcs.
+        self._firewall = {} # dict of all the allowed connections in the environment. Keys `IP` ,values: `set` of `IP` objects.
         # All exploits in the environment
         self._exploits = {}
         # A list of all the hosts where the attacker can start in a random start
@@ -688,7 +688,7 @@ class NetworkSecurityEnvironment(object):
             for dst_ip in dst_ips:
                 new_self_firewall[mapping_ips[ip]].add(mapping_ips[dst_ip])
         self._firewall = new_self_firewall
-        
+
         #self._ip_to_hostname
         new_self_ip_to_hostname  = {}
         for ip, hostname in self._ip_to_hostname.items():

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -1087,6 +1087,7 @@ class NetworkSecurityEnvironment(object):
             self._actions_played.append(action)
 
             # 1. Perform the action
+            self._actions_played.append(action)
             if random.random() <= action.type.default_success_p or action_type == 'realworld':
                 next_state = self._execute_action(self._current_state, action, action_type=action_type)
             else:

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -803,7 +803,7 @@ class NetworkSecurityEnvironment(object):
         except KeyError:
             connection_allowed = False
         return connection_allowed
-        e
+
     def _execute_scan_network_action(self, current:components.GameState, action:components.Action)->components.GameState:
         """
         Executes the ScanNetwork action in the environment
@@ -815,8 +815,11 @@ class NetworkSecurityEnvironment(object):
             for ip in self._ip_to_hostname.keys(): #check if IP exists
                 logger.info(f"\t\tChecking if {ip} in {action.parameters['target_network']}")
                 if str(ip) in netaddr.IPNetwork(str(action.parameters["target_network"])):
-                    logger.info(f"\t\t\tAdding {ip} to new_ips")
-                    new_ips.add(ip)
+                    if self._firewall_check(action.parameters["source_host"], ip):
+                        logger.info(f"\t\t\tAdding {ip} to new_ips")
+                        new_ips.add(ip)
+                    else:
+                        logger.info(f"\t\t\tConnection {action.parameters['source_host']} -> {ip} blocked by FW. Skipping")
             next_known_h = next_known_h.union(new_ips)
         else:
             logger.info(f"\t\t\t Invalid source_host:'{action.parameters['source_host']}'")

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -575,6 +575,8 @@ class NetworkSecurityEnvironment(object):
                                 for src in ips:
                                     for dst in public_ips:
                                         firewall[src].add(dst)
+                                        #add self loop:
+                                        firewall[dst].add(dst)
                 # FW RULES FROM CONFIG
                 for rule in fw_rules:
                     if rule.policy == FirewallPolicy.ALLOW:

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -160,6 +160,9 @@ class NetworkSecurityEnvironment(object):
         self.hosts_to_start = []
         # Read the conf file passed by the agent for the rest of values
         self.task_config = ConfigParser(task_config_file)
+
+        # Read the conf for firewall usage
+        self._use_firewall = self.task_config.get_use_firewall()
         
         # Load CYST configuration
         self._process_cyst_config(self.task_config.get_scenario())

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -796,6 +796,14 @@ class NetworkSecurityEnvironment(object):
         next_data = copy.deepcopy(current.known_data)
         return next_nets, next_known_h, next_controlled_h, next_services, next_data
 
+    def _firewall_check(self, src_ip:components.IP, dst_ip:components.IP)->bool:
+        """Checks if firewall allows connection from 'src_ip to ''dst_ip'"""
+        try:
+            connection_allowed = dst_ip in self._firewall[src_ip]
+        except KeyError:
+            connection_allowed = False
+        return connection_allowed
+        e
     def _execute_scan_network_action(self, current:components.GameState, action:components.Action)->components.GameState:
         """
         Executes the ScanNetwork action in the environment

--- a/env/network_security_game.py
+++ b/env/network_security_game.py
@@ -856,13 +856,16 @@ class NetworkSecurityEnvironment(object):
         next_nets, next_known_h, next_controlled_h, next_services, next_data = self._state_parts_deep_copy(current)
         logger.info(f"\t\tSearching for data in {action.parameters['target_host']}")
         if "source_host" in action.parameters.keys() and action.parameters["source_host"] in current.controlled_hosts:
-            new_data = self._get_data_in_host(action.parameters["target_host"], current.controlled_hosts)
-            logger.info(f"\t\t\t Found {len(new_data)}: {new_data}")
-            if len(new_data) > 0:
-                if action.parameters["target_host"] not in next_data.keys():
-                    next_data[action.parameters["target_host"]] = new_data
-                else:
-                    next_data[action.parameters["target_host"]] = next_data[action.parameters["target_host"]].union(new_data)
+            if self._firewall_check(action.parameters["source_host"], action.parameters['target_host']):
+                new_data = self._get_data_in_host(action.parameters["target_host"], current.controlled_hosts)
+                logger.info(f"\t\t\t Found {len(new_data)}: {new_data}")
+                if len(new_data) > 0:
+                    if action.parameters["target_host"] not in next_data.keys():
+                        next_data[action.parameters["target_host"]] = new_data
+                    else:
+                        next_data[action.parameters["target_host"]] = next_data[action.parameters["target_host"]].union(new_data)
+            else:
+                logger.info(f"\t\t\tConnection {action.parameters['source_host']} -> {action.parameters['target_host']} blocked by FW. Skipping")
         else:
             logger.info(f"\t\t\t Invalid source_host:'{action.parameters['source_host']}'")
         return components.GameState(next_controlled_h, next_known_h, next_services, next_data, next_nets)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -430,6 +430,17 @@ class ConfigParser():
             # Option is not in the configuration - default to FALSE
             randomize_goal_every_episode = False
         return randomize_goal_every_episode
+    
+    def get_use_firewall(self)->bool:
+        """
+        Retrieves if the firewall functionality is allowed for netsecgame.
+        Default: False
+        """
+        try:
+            use_firewall = self.config['env']['use_firewall']
+        except KeyError:
+            use_firewall = False
+        return use_firewall
 
 if __name__ == "__main__":
     state = GameState(known_networks={Network("1.1.1.1", 24),Network("1.1.1.2", 24)},


### PR DESCRIPTION
Added FW support to the netsecgame. 

- new option in the task config "use_firewall" enables the functionality (default to False for backward compatibility)
- FW rules are analyzed as defined in CYST config:
    - hosts can reach other hosts in the same network
    - hosts from local networks can reach the hosts in the internet
    - Internet can't reach local hosts unless specifically defined in the scenario configuration
    - hosts can reach hosts in other subnetworks only if specifically defined in the scenario configuration
 - Each action processing method checks the compatibility with the FW rules