### PR TITLE
Role dependent timeout

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -498,7 +498,7 @@ class Coordinator:
                 self._agent_episode_ends[agent_addr] = True
                 end_reason = "goal_reached"
                 obs_info = {'end_reason': "goal_reached"}
-            elif self._agent_steps[agent_addr] >= self._steps_limit:
+            elif self._timeout_reached(agent_addr):
                 self._agent_episode_ends[agent_addr] = True
                 obs_info = {"end_reason": "max_steps"}
                 end_reason = "max_steps"
@@ -532,7 +532,7 @@ class Coordinator:
         end_reason = ""
         if self._agent_goal_reached[agent_addr]:
             end_reason = "goal_reached"
-        elif self._agent_steps[agent_addr] >= self._world.timeout:
+        elif self._timeout_reached(agent_addr):
             end_reason = "max_steps"
         else:
             end_reason = "game_lost"

--- a/coordinator.py
+++ b/coordinator.py
@@ -609,6 +609,16 @@ class Coordinator:
         else:
             self.logger.info("\tNot detected!")
         return detection
+    
+    def _timeout_reached(self, agent_addr:tuple) ->bool:
+        """
+        Checks if the agent reached the max allowed steps. Only applies to role 'Attacker'
+        """
+        if self.agents[agent_addr][0] == "Attacker":
+            return self._agent_steps[agent_addr] >= self._steps_limit
+        else:
+            return False
+
 __version__ = "v0.2.2"
 
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -614,8 +614,11 @@ class Coordinator:
         """
         Checks if the agent reached the max allowed steps. Only applies to role 'Attacker'
         """
-        if self.agents[agent_addr][0] == "Attacker":
-            return self._agent_steps[agent_addr] >= self._steps_limit
+        self.logger.debug(f"Checking timout for {self.agents[agent_addr]}")
+        if self.agents[agent_addr][1] == "Attacker":
+            if self._agent_steps[agent_addr] >= self._steps_limit:
+                self.logger.info("Timeout reached by {self.agents[agent_addr]}!")
+                return True
         else:
             return False
 

--- a/tests/manual/three_nets/three_net_testing_conf.yaml
+++ b/tests/manual/three_nets/three_net_testing_conf.yaml
@@ -58,7 +58,7 @@ env:
   # random_seed: 42
   scenario: 'three_nets'
   use_global_defender: False
-  max_steps: 50
+  max_steps: 15
   use_dynamic_addresses: False
   use_firewall: True
   save_trajectories: False

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -7,3 +7,6 @@ python3  -m pytest tests/test_actions.py -p no:warnings -vvvv -s --full-trace
 python3  -m pytest tests/test_components.py -p no:warnings -vvvv -s --full-trace
 python3  -m pytest tests/test_coordinator.py -p no:warnings -vvvv -s --full-trace
 
+# run ruff check as well
+ruff check --output-format=github --select=E9,F4,F6,F7,F8,N8 --ignore=F405 --target-version=py310 --line-length=120 .
+

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -8,5 +8,6 @@ python3  -m pytest tests/test_components.py -p no:warnings -vvvv -s --full-trace
 python3  -m pytest tests/test_coordinator.py -p no:warnings -vvvv -s --full-trace
 
 # run ruff check as well
+echo "Running RUFF check: in ${PWD}"
 ruff check --output-format=github --select=E9,F4,F6,F7,F8,N8 --ignore=F405 --target-version=py310 --line-length=120 .
 


### PR DESCRIPTION
Introduces change in which only the attackers can reach the timeout. Other agent types have an infinite amount of steps. This change prevents defenders from forcing the episode to end. Currently, the game ends when the attacker reaches the goal, OR it reaches the timeout.

Added test for the timeout