### PR TITLE
Send trajectories to agents

### DIFF
--- a/AIDojoCoordinator/coordinator.py
+++ b/AIDojoCoordinator/coordinator.py
@@ -382,7 +382,7 @@ class GameCoordinator:
                         self._spawn_task(self._process_quit_game_action, agent_addr)
                     case ActionType.ResetGame:
                         self.logger.debug(f"Start processing of ActionType.ResetGame by {agent_addr}")
-                        self._spawn_task(self._process_reset_game_action, agent_addr)
+                        self._spawn_task(self._process_reset_game_action, agent_addr, action)
                     case ActionType.ExfiltrateData | ActionType.FindData | ActionType.ScanNetwork | ActionType.FindServices | ActionType.ExploitService:
                         self.logger.debug(f"Start processing of {action.type} by {agent_addr}")
                         self._spawn_task(self._process_game_action, agent_addr, action)
@@ -468,7 +468,7 @@ class GameCoordinator:
         finally:
             self.logger.debug(f"Cleaning up after QuitGame for {agent_addr}.")
     
-    async def _process_reset_game_action(self, agent_addr: tuple)->None:
+    async def _process_reset_game_action(self, agent_addr: tuple, reset_action:Action)->None:
         """
         Method for processing Action of type ActionType.ResetGame
         Inputs: 

--- a/AIDojoCoordinator/coordinator.py
+++ b/AIDojoCoordinator/coordinator.py
@@ -71,7 +71,8 @@ class AgentServer(asyncio.Protocol):
                 self.logger.info(f"Sending response to agent {addr}: {response}")
 
                 # Step 4: Send the response to the agent
-                writer.write(bytes(str(response).encode()))
+                response = str(response) + "EOF"
+                writer.write(response.encode())
                 await writer.drain()
         except asyncio.CancelledError:
             self.logger.debug("Terminating by KeyboardInterrupt")

--- a/AIDojoCoordinator/docs/Components.md
+++ b/AIDojoCoordinator/docs/Components.md
@@ -53,7 +53,7 @@ Actions are the objects sent by the agents to the environment. Each action is ev
 
 In all cases, when an agent sends an action to AIDojo, it is given a response.
 ### Action format
-The Action class is defined in `env.game_components.py`. It has two basic parts:
+The Action class is defined in `game_components.py`. It has two basic parts:
 1. ActionType:Enum
 2. parameters:dict
 
@@ -61,7 +61,7 @@ ActionType is unique Enum that determines what kind of action is agent playing. 
 ### List of actions
 - **JoinGame**, params={`agent_info`:AgentInfo(\<name\>, \<role\>)}: Used to register agent in a game with a given \<role\>.
 - **QuitGame**, params={}: Used for termination of agent's interaction.
-- **ResetGame**, params={}: Used for requesting reset of the game to it's initial position.
+- **ResetGame**, params={`request_trajectory`:`bool`}: Used for requesting reset of the game to it's initial position. If `request_trajectory = True`, the coordinator will send back the complete trajectory of the previous run in the next message.
 ---
 - **ScanNetwork**, params{`source_host`:\<IP\>, `target_network`:\<Network\>}: Scans the given \<Network\> from a specified source host. Discovers ALL hosts in a network that are accessible from \<IP\>. If successful, returns set of discovered \<IP\> objects.
 - **FindServices**, params={`source_host`:\<IP\>, `target_host`:\<IP\>}: Used to discover ALL services running in the `target_host` if the host is accessible from `source_host`. If successful, returns a set of all discovered \<Service\> objects.

--- a/AIDojoCoordinator/game_components.py
+++ b/AIDojoCoordinator/game_components.py
@@ -473,3 +473,8 @@ class AgentStatus(enum.Enum):
             return cls[name]
         except KeyError:
             raise ValueError(f"Invalid AgentStatus: {name}")
+
+@dataclass(frozen=True)
+class ProtocolConfig:
+    END_OF_MESSAGE = b"EOF"
+    BUFFER_SIZE = 8192 

--- a/AIDojoCoordinator/game_components.py
+++ b/AIDojoCoordinator/game_components.py
@@ -237,6 +237,8 @@ class Action:
                     params[k] = Data.from_dict(v)
                 case "agent_info":
                     params[k] = AgentInfo.from_dict(v)
+                case "request_trajectory":
+                    params[k] = bool(v)
                 case _:
                     raise ValueError(f"Unsupported value in {k}: {v}")
         return cls(action_type=action_type, parameters=params)


### PR DESCRIPTION
Re-worked agent-coordinator communication in which the sender appends the EOF marker to indicate the end of the message. Trajectories can be requested in ResetGame message. If requested, the *last* trajectory is sent to the agent in the response