### PR TITLE
Fix adding known networks from controlled hosts

### DIFF
--- a/AIDojoCoordinator/worlds/NSEGameCoordinator.py
+++ b/AIDojoCoordinator/worlds/NSEGameCoordinator.py
@@ -142,8 +142,8 @@ class NSGCoordinator(GameCoordinator):
             for controlled_host in controlled_hosts:
                 for net in self._get_networks_from_host(controlled_host): #TODO
                     net_obj = netaddr.IPNetwork(str(net))
+                    known_networks.add(net)
                     if net_obj.ip.is_private(): #TODO
-                        known_networks.add(net)
                         net_obj.value += 256
                         if net_obj.ip.is_private():
                             ip = Network(str(net_obj.ip), net_obj.prefixlen)
@@ -156,6 +156,10 @@ class NSGCoordinator(GameCoordinator):
                             known_networks.add(ip)
                         #return value back to the original
                         net_obj.value += 256
+        else:
+            for controlled_host in controlled_hosts:
+                for net in self._get_networks_from_host(controlled_host): #TODO
+                    known_networks.add(net)
         # parse known services
         known_services = self._get_services_from_view(view["known_services"])
         # parse known data


### PR DESCRIPTION
In the WhiteBoxNSGCoordinator, the known_networks were incorrectly extracted from the controlled hosts resulting in an empty set. In some cases, that made the game unsolvable.