### PR TITLE
Ondra fix seed2 network mapping

### DIFF
--- a/netsecgame/game/worlds/NetSecGame.py
+++ b/netsecgame/game/worlds/NetSecGame.py
@@ -745,7 +745,7 @@ class NetSecGame(GameCoordinator):
                 
                 if all(checks): 
                     valid_network_mapping = True
-            except IndexError as e:
+            except IndexError:
                 counter_iter += 1
                 self.logger.warning(f"Invalid mapping created: {mapping_nets}. Remaining attempts: {max_attempts - counter_iter}")
                 if counter_iter > max_attempts:

--- a/netsecgame/game/worlds/NetSecGame.py
+++ b/netsecgame/game/worlds/NetSecGame.py
@@ -701,20 +701,9 @@ class NetSecGame(GameCoordinator):
         Returns:
             Tuple[Dict[Network, Network], Dict[IP, IP]]: The network and IP mappings.
         """
-        #self.logger.info(f"Generating new network and IP address mapping with seed {seed} (max attempts: {max_attempts})")
-
-        # # setup random generators
-        # if seed is not None:
-        #     fake = Faker()
-        #     fake.seed_instance(seed)
-        #     rng = random.Random(seed)
-        # else:
-        #     fake = self._faker_object
-        #     rng = random
         fake = self._faker_object
         rng = random
         
-
         mapping_nets = {}
         mapping_ips = {}
         

--- a/netsecgame/game/worlds/NetSecGame.py
+++ b/netsecgame/game/worlds/NetSecGame.py
@@ -708,7 +708,7 @@ class NetSecGame(GameCoordinator):
         mapping_ips = {}
         
         # sort networks for deterministic processing (order should be deterministic in Python 3.7+ but we enforce it)
-        sorted_networks = sorted(self._networks.keys(), key=str)
+        sorted_networks = sorted(self._networks.keys(), key=lambda x: netaddr.IPNetwork(str(x)).ip)
 
         # generate network mappings (Preserves distance between private networks)
         private_nets = []

--- a/netsecgame/game/worlds/NetSecGame.py
+++ b/netsecgame/game/worlds/NetSecGame.py
@@ -719,7 +719,8 @@ class NetSecGame(GameCoordinator):
                 mapping_nets[net] = Network(fake.ipv4_public(), net.mask)
         
         # Private Network logic
-        valid_network_mapping = False
+        # if no private networks, we are done, otherwise generate new mapping
+        valid_network_mapping = len(private_nets) == 0
         counter_iter = 0
         
         while not valid_network_mapping:

--- a/netsecgame/game/worlds/NetSecGame.py
+++ b/netsecgame/game/worlds/NetSecGame.py
@@ -745,8 +745,9 @@ class NetSecGame(GameCoordinator):
                 
                 if all(checks): 
                     valid_network_mapping = True
-            except IndexError:
+            except IndexError as e:
                 counter_iter += 1
+                self.logger.warning(f"Invalid mapping created: {mapping_nets}. Remaining attempts: {max_attempts - counter_iter}")
                 if counter_iter > max_attempts:
                     self.logger.error(f"Failed to generate valid network mapping in {max_attempts} attempts - exiting.")
                     exit(-1)


### PR DESCRIPTION
# Description

In certain cases, the networks were not ordered correctly, and then the offset was not consistent, resulting in an error.

Fixes # (issue)
Fixed the ordering, added better logging and additional checks

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manual testing (local run with NetSecGame)
- [x] Manual testing (local run with WhiteBoxNetSecGame)
- [x] Local docker run with NetSecGame
- [x] Local docker run with WhiteBoxNetSecGame


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have run local pytest
- [x] I have run local ruff check